### PR TITLE
Add Checkstyle check to ban Guava Precondtions

### DIFF
--- a/1.0/config/checkstyle/checkstyle.xml
+++ b/1.0/config/checkstyle/checkstyle.xml
@@ -18,6 +18,11 @@
       <property name="regexp" value="true" />
       <property name="illegalClasses" value="^junit\.framework\..+,^org\.junit\.Assert\..+,^org\.junit\.Assume\.assumeThat,^org\.junit\.rules\.ExpectedException,^org\.hamcrest\.CoreMatchers.*" />
     </module>
+    <module name="IllegalImport">
+      <property name="id" value="bannedGuavaPreconditionsInFavorOfApacheValidate" />
+      <property name="regexp" value="true" />
+      <property name="illegalClasses" value="^com\.google\.common\.base\.Preconditions.*" />
+    </module>
     <module name="IllegalInstantiation"/>
     <module name="InnerAssignment"/>
     <module name="LeftCurly">


### PR DESCRIPTION
This commit adds Checkstyle check that bans Guava Precondtions in favor of
Apache Commons Validate