### PR TITLE
[PMD] Remove deprecated configuration of `ImmutableField` rule

### DIFF
--- a/2.0/config/pmd/pmdMain-ruleset.xml
+++ b/2.0/config/pmd/pmdMain-ruleset.xml
@@ -44,11 +44,6 @@
             <property name="methodReportLevel" value="24"/>
         </properties>
     </rule>
-    <rule ref="category/java/design.xml/ImmutableField">
-        <properties>
-            <property name="ignoredAnnotations" value="javax.inject.Inject" />
-        </properties>
-    </rule>
 
     <rule ref="category/java/documentation.xml">
         <exclude name="CommentContent"/>


### PR DESCRIPTION
https://docs.pmd-code.org/pmd-doc-6.55.0/pmd_rules_java_design.html#immutablefield: The property `ignoredAnnotations` is deprecated since PMD 6.52.0 and doesn’t have any effect anymore.